### PR TITLE
Fixed missing virtual function

### DIFF
--- a/Source/XnDeviceSensorV2/XnSensorDepthGenerator.cpp
+++ b/Source/XnDeviceSensorV2/XnSensorDepthGenerator.cpp
@@ -244,6 +244,12 @@ XnStatus XnSensorDepthGenerator::SetViewPoint(xn::ProductionNode& OtherNode)
 	}
 }
 
+XnStatus
+XnSensorDepthGenerator::GetPixelCoordinatesInViewPoint(xn::ProductionNode& other, XnUInt32 x, XnUInt32 y, XnUInt32& altX, XnUInt32& altY)
+{
+      return 0;
+}
+
 XnStatus XnSensorDepthGenerator::ResetViewPoint()
 {
 	return SetIntProperty(XN_STREAM_PROPERTY_REGISTRATION, FALSE);

--- a/Source/XnDeviceSensorV2/XnSensorDepthGenerator.h
+++ b/Source/XnDeviceSensorV2/XnSensorDepthGenerator.h
@@ -67,6 +67,7 @@ public:
 	xn::ModuleAlternativeViewPointInterface* GetAlternativeViewPointInterface() { return this; }
 	XnBool IsViewPointSupported(xn::ProductionNode& OtherNode);
 	XnStatus SetViewPoint(xn::ProductionNode& OtherNode);
+  XnStatus GetPixelCoordinatesInViewPoint(xn::ProductionNode& other, XnUInt32 x, XnUInt32 y, XnUInt32& altX, XnUInt32& altY);
 	XnStatus ResetViewPoint();
 	XnBool IsViewPointAs(xn::ProductionNode& OtherNode);
 	XnStatus RegisterToViewPointChange(XnModuleStateChangedHandler handler, void* pCookie, XnCallbackHandle& hCallback);


### PR DESCRIPTION
@ph4m, I've adjusted your origianl PR (https://github.com/avin2/SensorKinect/pull/5) for this repository, with all  credits to you. Let me know if this is a problem.
PointCloud Library maintainers, this PR fixes the following error, when running `Platform/Linux/CreateRedist/RedistMaker`:

`
In file included from /usr/include/ni/XnTypes.h:28:0,
                 from /usr/include/ni/XnModuleInterface.h:27,
                 from /usr/include/ni/XnModuleCppInterface.h:33,
                 from ../../../../Source/XnDeviceSensorV2/XnSensorProductionNode.h:28,
                 from ../../../../Source/XnDeviceSensorV2/XnSensorGenerator.h:28,
                 from ../../../../Source/XnDeviceSensorV2/XnSensorMapGenerator.h:28,
                 from ../../../../Source/XnDeviceSensorV2/XnSensorDepthGenerator.h:28,
                 from ../../../../Source/XnDeviceSensorV2/XnSensorDepthGenerator.cpp:25:
../../../../Source/XnDeviceSensorV2/XnSensorDepthGenerator.cpp: In member function ‘virtual XnSensorGenerator* XnExportedSensorDepthGenerator::CreateGenerator(xn::Context&, xn::Device&, XnDeviceBase*, const XnChar*)’:
/usr/include/ni/XnOS.h:331:49: error: invalid new-expression of abstract class type ‘XnSensorDepthGenerator’
  #define XN_NEW(type, ...)  new type(__VA_ARGS__)
                                                 ^
`